### PR TITLE
Drop installation of apt-chef

### DIFF
--- a/recipes/solo.rb
+++ b/recipes/solo.rb
@@ -81,14 +81,12 @@ else
         end
       end
 
-      %w(apt-chef chef-server-populator).each do |cb|
-        execute "#{k} - install #{cb} cookbook" do
-          command "#{knife_cmd} cookbook upload #{cb} #{knife_opts} -o #{Chef::Config[:cookbook_path].join(':')} --include-dependencies"
-          only_if do
-            node[:chef_server_populator][:cookbook_auto_install]
-          end
-          retries 5
+      execute 'install chef-server-populator cookbook' do
+        command "#{knife_cmd} cookbook upload chef-server-populator #{knife_opts} -o #{Chef::Config[:cookbook_path].join(':')} --include-dependencies"
+        only_if do
+          node[:chef_server_populator][:cookbook_auto_install]
         end
+        retries 5
       end
     end
 end


### PR DESCRIPTION
See darkskyapp/chef-server-populator@b692d35ae7b964b51021fbed3dd58ee3efbaf008 for discussion. Figured I’d share what I’ve already done.

This reverts commit b692d35ae7b964b51021fbed3dd58ee3efbaf008.